### PR TITLE
add workspace folder as target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 set -o pipefail
 
-
 REPO=${repo:=open-component-model/ocm}
 WORKSPACE=${GITHUB_WORKSPACE:=/usr/local}
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 set -o pipefail
 
+
 REPO=${repo:=open-component-model/ocm}
-: ${WORKSPACE:=/usr/local}
+WORKSPACE=${GITHUB_WORKSPACE:=/usr/local}
 
 if [ -z "$version" -o "$version" == latest ]; then
   version="$(basename "$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/$REPO/releases/latest)")"
@@ -29,3 +30,5 @@ echo "ocm installed into $TARGET"
 if [ -n "$GITHUB_OUTPUT" ]; then
   echo "ocm-path=$TARGET" >> "$GITHUB_OUTPUT"
 fi
+# add installation folder to PATH to be able to use "which ocm" in subsequent steps to detect installation path
+echo "$WORKSPACE" >> $GITHUB_PATH


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
use GITHUB_WORKSPACE as default target folder for OCM binary download
